### PR TITLE
Make "Personal Website" icon consistent across all team members.

### DIFF
--- a/_data/socialmedia.yml
+++ b/_data/socialmedia.yml
@@ -34,7 +34,7 @@
       title: "Professional LinkedIn account"
     - name: Link
       url: http://alexwagner.info/
-      class: icon-network
+      class: icon-link
       title: "Personal Website"
 
 - member_name: Malachi


### PR DESCRIPTION
Everyone else was using the "link" icon, so this one is changed to match.  I make no claims as to which of the two icons is a better choice :smile: